### PR TITLE
Refactor and add power-saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build artifacts
+*.elf
+*.bin
+*.hex
+*.o
+
+# Arduino build folder
+build/
+
+# User config
+config.h
+
+# OS files
+.DS_Store
+
+# Archives
+*.zip

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MQTTManager.cpp
+++ b/MQTTManager.cpp
@@ -2,16 +2,17 @@
 #include <WiFi.h>
 #include <PubSubClient.h>
 #include "ValveController.h"
+#include "config.h"
 
 extern ValveController valve;
 
 WiFiClient espClient;
 PubSubClient client(espClient);
 
-const char* mqtt_server = "192.168.0.114";
-const char* topic = "sprinkler/mastervalve";
+const char* mqtt_server = MQTT_SERVER;
+const char* mqtt_topic = "sprinkler/mastervalve";
 
-void callback(char* topic, byte* payload, unsigned int length) {
+void callback(char* receivedTopic, byte* payload, unsigned int length) {
   String msg = "";
   for (unsigned int i = 0; i < length; i++) {
     msg += (char)payload[i];
@@ -27,7 +28,7 @@ void reconnect() {
     Serial.print("Attempting MQTT connection...");
     if (client.connect("ESP32_MasterValve")) {
       Serial.println("connected");
-      client.subscribe(topic);
+      client.subscribe(mqtt_topic);
     } else {
       Serial.print("failed, rc=");
       Serial.print(client.state());

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # Sprinkler
-A Master Valve, environmental monitor, and sprinkler remote control
+
+This project contains Arduino sketches for controlling a master irrigation valve and a base unit that reports valve status over MQTT. It runs on the ESP32 platform and communicates with a Wi-Fi network and MQTT broker.
+
+## Hardware
+- ESP32 development board
+- Relay or MOSFET to drive the valve (connected to GPIO 32 by default)
+- Valve position sensor for the base unit (connected to GPIO 25)
+
+## Setup
+1. Copy `config.h.example` to `config.h` and fill in your Wi-Fi credentials and MQTT broker address.
+2. Open `master_valve_main.ino` (or `base_unit.ino`) in the Arduino IDE or PlatformIO.
+3. Install the required libraries:
+   - `WiFi` (built into ESP32 package)
+   - `PubSubClient`
+4. Select the appropriate ESP32 board and compile/upload the sketch.
+
+## Power Saving
+The Wi-Fi manager enables modem sleep mode to reduce power consumption while maintaining network connectivity.
+
+## Files
+- `master_valve_main.ino` – main sketch controlling the valve
+- `base_unit.ino` – publishes valve sensor status
+- `ValveController.*` – controls the valve hardware
+- `MQTTManager.*` – handles MQTT messages
+- `WiFiManager.*` – connects to Wi-Fi
+- `Watchdog.*` – feeds the watchdog timer
+
+## License
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1,11 +1,11 @@
 #include "WiFiManager.h"
 #include <WiFi.h>
-
-const char* ssid = "Artemis";
-const char* password = "Gocards1";
+#include "config.h"
 
 void WiFiManager::connect() {
-  WiFi.begin(ssid, password);
+  WiFi.mode(WIFI_STA);
+  WiFi.setSleep(true); // enable modem sleep for lower power consumption
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   Serial.print("Connecting to WiFi");
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);

--- a/base_unit.ino
+++ b/base_unit.ino
@@ -1,9 +1,8 @@
 #include <WiFi.h>
 #include <PubSubClient.h>
+#include "config.h"
 
-const char* ssid = "Artemis";
-const char* password = "Gocards1";
-const char* mqtt_server = "192.168.0.114";
+const char* mqtt_server = MQTT_SERVER;
 const char* topic = "sprinkler/mastervalve";
 
 #define VALVE_SENSOR_PIN 25
@@ -13,7 +12,9 @@ PubSubClient client(espClient);
 
 void setup_wifi() {
   Serial.begin(115200);
-  WiFi.begin(ssid, password);
+  WiFi.mode(WIFI_STA);
+  WiFi.setSleep(true);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");

--- a/config.h.example
+++ b/config.h.example
@@ -1,0 +1,11 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+// Wi-Fi credentials
+const char* WIFI_SSID = "your-ssid";
+const char* WIFI_PASSWORD = "your-password";
+
+// MQTT broker address
+const char* MQTT_SERVER = "192.168.0.114";
+
+#endif // CONFIG_H


### PR DESCRIPTION
## Summary
- drop redundant `master_valve.zip`
- add `.gitignore`
- add MIT license
- move credentials to `config.h.example`
- enable modem sleep for Wi‑Fi
- clean up MQTT callback and add config header use
- document setup & power saving in README

## Testing
- `cppcheck --language=c++ *.cpp *.ino`


------
https://chatgpt.com/codex/tasks/task_e_6844eaa4df388327a89c045537672d03