### PR TITLE
Introduce config header for network settings

### DIFF
--- a/MQTTManager.cpp
+++ b/MQTTManager.cpp
@@ -2,13 +2,13 @@
 #include <WiFi.h>
 #include <PubSubClient.h>
 #include "ValveController.h"
+#include "config.h"
 
 extern ValveController valve;
 
 WiFiClient espClient;
 PubSubClient client(espClient);
 
-const char* mqtt_server = "192.168.0.114";
 const char* topic = "sprinkler/mastervalve";
 
 void callback(char* topic, byte* payload, unsigned int length) {
@@ -38,7 +38,7 @@ void reconnect() {
 }
 
 void MQTTManager::begin() {
-  client.setServer(mqtt_server, 1883);
+  client.setServer(MQTT_SERVER, 1883);
   client.setCallback(callback);
 }
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Sprinkler
 A Master Valve, environmental monitor, and sprinkler remote control
+
+## Configuration
+
+Network credentials and the MQTT broker address are stored in `config.h`.  
+Edit the values for `WIFI_SSID`, `WIFI_PASSWORD` and `MQTT_SERVER` before
+compiling the project:
+
+```cpp
+#define WIFI_SSID "your_wifi_name"
+#define WIFI_PASSWORD "your_wifi_password"
+#define MQTT_SERVER "mqtt_broker_ip"
+```

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -1,11 +1,9 @@
 #include "WiFiManager.h"
 #include <WiFi.h>
-
-const char* ssid = "Artemis";
-const char* password = "Gocards1";
+#include "config.h"
 
 void WiFiManager::connect() {
-  WiFi.begin(ssid, password);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   Serial.print("Connecting to WiFi");
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);

--- a/base_unit.ino
+++ b/base_unit.ino
@@ -1,9 +1,7 @@
 #include <WiFi.h>
 #include <PubSubClient.h>
+#include "config.h"
 
-const char* ssid = "Artemis";
-const char* password = "Gocards1";
-const char* mqtt_server = "192.168.0.114";
 const char* topic = "sprinkler/mastervalve";
 
 #define VALVE_SENSOR_PIN 25
@@ -13,7 +11,7 @@ PubSubClient client(espClient);
 
 void setup_wifi() {
   Serial.begin(115200);
-  WiFi.begin(ssid, password);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");
@@ -36,7 +34,7 @@ void reconnect() {
 
 void setup() {
   setup_wifi();
-  client.setServer(mqtt_server, 1883);
+  client.setServer(MQTT_SERVER, 1883);
   pinMode(VALVE_SENSOR_PIN, INPUT);
 }
 

--- a/config.h
+++ b/config.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// WiFi credentials
+#define WIFI_SSID "Artemis"
+#define WIFI_PASSWORD "Gocards1"
+
+// MQTT broker address
+#define MQTT_SERVER "192.168.0.114"


### PR DESCRIPTION
## Summary
- centralize WiFi and MQTT settings in `config.h`
- update WiFiManager, MQTTManager and base unit sketch to use the new header
- document configuration of credentials in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844ed4eecc88327a98e65676df14cbf