### PR TITLE
Add debug message and delay to master valve

### DIFF
--- a/master_valve_main.ino
+++ b/master_valve_main.ino
@@ -9,6 +9,7 @@ Watchdog watchdog;
 
 void setup() {
   Serial.begin(115200);
+  Serial.println("Master Valve starting...");
   WiFiManager::connect();
   valve.begin();
   mqtt.begin();
@@ -19,4 +20,5 @@ void loop() {
   mqtt.loop();
   valve.update();
   watchdog.feed();
+  delay(10);
 }


### PR DESCRIPTION
## Summary
- print a startup banner in `setup()` for the master valve sketch
- slow down the loop slightly with a small delay

## Testing
- `platformio ci --board=esp32dev master_valve_main.ino` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_6844f1c1069c8327ac5cefa75e77f0ec